### PR TITLE
Add new numbers starting with "96" in Nepal.

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -206,7 +206,7 @@ var iso3166_data = [
 	{alpha2: "NU", alpha3: "NIU", country_code: "683", country_name: "Niue", mobile_begin_with: [], phone_number_lengths: [4]},
 	{alpha2: "NL", alpha3: "NLD", country_code: "31", country_name: "Netherlands", mobile_begin_with: ["6"], phone_number_lengths: [9]},
 	{alpha2: "NO", alpha3: "NOR", country_code: "47", country_name: "Norway", mobile_begin_with: ["4", "9"], phone_number_lengths: [8]},
-	{alpha2: "NP", alpha3: "NPL", country_code: "977", country_name: "Nepal", mobile_begin_with: ["97", "98"], phone_number_lengths: [10]},
+	{alpha2: "NP", alpha3: "NPL", country_code: "977", country_name: "Nepal", mobile_begin_with: ["96", "97", "98"], phone_number_lengths: [10]},
 	{alpha2: "NR", alpha3: "NRU", country_code: "674", country_name: "Nauru", mobile_begin_with: ["555"], phone_number_lengths: [7]},
 	{alpha2: "NZ", alpha3: "NZL", country_code: "64", country_name: "New Zealand", mobile_begin_with: ["2"], phone_number_lengths: [8, 9, 10]},
 	{alpha2: "OM", alpha3: "OMN", country_code: "968", country_name: "Oman", mobile_begin_with: ["9"], phone_number_lengths: [8]},

--- a/test/index.js
+++ b/test/index.js
@@ -495,7 +495,7 @@ describe('Testing NPL Phone Quick Test', function() {
 
 	describe('Test NP 1', function() {
 		var number = '09812345678', // remove the leading 0
-			country = 'THA',
+			country = 'NPL',
 			result = ['+9779812345678', 'NPL'];
 		it('returns ' + result, function() {
 			phone(number, country).should.eql(result);

--- a/test/index.js
+++ b/test/index.js
@@ -490,3 +490,52 @@ describe('Testing THA Phone Quick Test', function() {
 	});
 
 });
+
+describe('Testing NPL Phone Quick Test', function() {
+
+	describe('Test NP 1', function() {
+		var number = '09812345678', // remove the leading 0
+			country = 'THA',
+			result = ['+9779812345678', 'NPL'];
+		it('returns ' + result, function() {
+			phone(number, country).should.eql(result);
+		});
+	});
+
+	describe('Test NP 2', function() {
+		var number = '09712345678', // remove the leading 0
+			country = 'NPL',
+			result = ['+9779712345678', 'NPL'];
+		it('returns ' + result, function() {
+			phone(number, country).should.eql(result);
+		});
+	});
+
+	describe('Test NP 3', function() {
+		var number = '09612345678',
+			country = 'NPL',
+			result = ['+9779612345678', 'NPL'];
+		it('returns ' + result, function() {
+			phone(number, country).should.eql(result);
+		});
+	});
+	
+	describe('Test NP 4', function() {
+		var number = '+9779812345678',
+			country = 'NPL',
+			result = ['+9779812345678', 'NPL'];
+		it('returns ' + result, function() {
+			phone(number, country).should.eql(result);
+		});
+	});
+	
+	describe('Test NP 5', function() {
+		var number = '9812345678',
+			country = 'NPL',
+			result = ['+9779812345678', 'NPL'];
+		it('returns ' + result, function() {
+			phone(number, country).should.eql(result);
+		});
+	});
+
+});


### PR DESCRIPTION
Recently new phone numbers have come in use  which start with "96".