### PR TITLE
Austrian phone numbers are of variable length

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -48,7 +48,7 @@ var iso3166_data = [
 	// http://www.howtocallabroad.com/results.php?callfrom=united_states&callto=antigua_barbuda
 	{alpha2: "AG", alpha3: "ATG", country_code: "1", country_name: "Antigua and Barbuda", mobile_begin_with: ["2687"], phone_number_lengths: [10]},
 	{alpha2: "AU", alpha3: "AUS", country_code: "61", country_name: "Australia", mobile_begin_with: ["4"], phone_number_lengths: [9]},
-	{alpha2: "AT", alpha3: "AUT", country_code: "43", country_name: "Austria", mobile_begin_with: ["6"], phone_number_lengths: [10]},
+	{alpha2: "AT", alpha3: "AUT", country_code: "43", country_name: "Austria", mobile_begin_with: ["6"], phone_number_lengths: [10, 11, 12, 13, 14]},
 	{alpha2: "AZ", alpha3: "AZE", country_code: "994", country_name: "Azerbaijan", mobile_begin_with: ["4", "5", "6", "7"], phone_number_lengths: [9]},
 	{alpha2: "BI", alpha3: "BDI", country_code: "257", country_name: "Burundi", mobile_begin_with: ["7", "29"], phone_number_lengths: [8]},
 	{alpha2: "BE", alpha3: "BEL", country_code: "32", country_name: "Belgium", mobile_begin_with: ["4"], phone_number_lengths: [9]},


### PR DESCRIPTION
In Austria, they have variable length phone numbers per provider, with this change we won't mark long valid mobile phone numbers as invalid anymore.