### PR TITLE
expose iso3166 in the result

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -454,7 +454,7 @@ module.exports = function(phone, country) {
 	}
 
 	if (validate_phone_iso3166(phone, iso3166)) {
-		return ['+' + phone, iso3166.alpha3];
+		return ['+' + phone, iso3166.alpha3, iso3166];
 	}
 	return result;
 };


### PR DESCRIPTION
Hi, we need to access the data in iso3166 to get the `country_code` from the result. Exposing the whole iso3166 would not break the API and is a bit more flexible for potential other needs.