### PR TITLE
export internal ISO3166 datum retrieval methods for use with external code

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -458,3 +458,6 @@ module.exports = function(phone, country) {
 	}
 	return result;
 };
+
+module.exports.getISO3166 = getISO3166;
+module.exports.getISO3166ByPhone = get_iso3166_by_phone;


### PR DESCRIPTION
(eg. pre-filling intl prefixes)