### PR TITLE
Add support for 7 and 9 number lengths for Somali phone numbers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1535,7 +1535,7 @@ var iso3166_data = [
 		country_code: "252",
 		country_name: "Somalia",
 		mobile_begin_with: ["9"],
-		phone_number_lengths: [8]
+		phone_number_lengths: [7, 8, 9]
 	},
 	{
 		alpha2: "SX",


### PR DESCRIPTION
Phone numbers within Somalia can consist of 7, 8 or 9 numbers (excluding the country code).  Here is a wikipedia link to be used as reference: https://en.wikipedia.org/wiki/Telephone_numbers_in_Somalia