### PR TITLE
add new KAZ phone number prefix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -874,7 +874,7 @@ var iso3166_data = [
 		alpha3: "KAZ",
 		country_code: "7",
 		country_name: "Kazakhstan",
-		mobile_begin_with: ["70", "77"],
+		mobile_begin_with: ["70", "74", "77"],
 		phone_number_lengths: [10]
 	},
 	{

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
 	"name": "phone",
-	"version": "1.0.9",
+	"version": "1.0.10",
 	"description": "With a given country and phone number, validate and format the phone number to E.164 standard",
 	"main": "./lib/index",
 	"engines": {

--- a/test/index.js
+++ b/test/index.js
@@ -878,3 +878,34 @@ describe('Testing TZA Phone Quick Test', function() {
 	});
 
 });
+
+describe('Testing KAZ Phone Quick Test', function() {
+
+	describe('Test 1', function() {
+		var number = '+77012345678',
+			country = 'KAZ',
+			result = ['+77012345678', 'KAZ'];
+		it('returns ' + result, function() {
+			phone(number, country).should.eql(result);
+		});
+	});
+
+	describe('Test 2', function() {
+		var number = '+77412345678',
+			country = 'KAZ',
+			result = ['+77412345678', 'KAZ'];
+		it('returns ' + result, function() {
+			phone(number, country).should.eql(result);
+		});
+	});
+
+	describe('Test 3', function() {
+		var number = '+77712345678',
+			country = 'KAZ',
+			result = ['+77712345678', 'KAZ'];
+		it('returns ' + result, function() {
+			phone(number, country).should.eql(result);
+		});
+	});
+
+});


### PR DESCRIPTION
74 is a new valid prefix for KAZ phones.

According to [this](https://rawgit.com/googlei18n/libphonenumber/master/javascript/i18n/phonenumbers/demo-compiled.html)

> ****Parsing Result:****
> {"country_code":7,"national_number":7471234567,"raw_input":"77471234567","country_code_source":10}
> 
> ****Validation Results:****
> Result from isPossibleNumber(): true
> Result from isValidNumber(): true
> Result from isValidNumberForRegion(): true
> Phone Number region: KZ
> Result from getNumberType(): MOBILE
> 
> ****Formatting Results:**** 
> E164 format: +77471234567
> Original format: 7 747 123 4567
> National format: 8 (747) 123 4567
> International format: +7 747 123 4567
> Out-of-country format from US: 011 7 747 123 4567
> Out-of-country format from Switzerland: 00 7 747 123 4567
> 
> ****AsYouTypeFormatter Results****
> Char entered: 7 Output: 7
> Char entered: 7 Output: 77
> Char entered: 4 Output: 774
> Char entered: 7 Output: 774-7
> Char entered: 1 Output: 774-71
> Char entered: 2 Output: 774-71-2
> Char entered: 3 Output: 774-71-23
> Char entered: 4 Output: 774 712 34
> Char entered: 5 Output: 774 712 345
> Char entered: 6 Output: 774 712 3456
> Char entered: 7 Output: 77471234567