### PR TITLE
add 12 number digit for Indonesian mobile phone

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -784,7 +784,7 @@ var iso3166_data = [
 		country_code: "62",
 		country_name: "Indonesia",
 		mobile_begin_with: ["8"],
-		phone_number_lengths: [9, 10, 11]
+		phone_number_lengths: [9, 10, 11, 12]
 	},
 	//{alpha2: "IM", alpha3: "IMN", country_code: "44", country_name: "Isle of Man", mobile_begin_with: [], phone_number_lengths: []},
 	{


### PR DESCRIPTION
Recently Indonesia start to introduce 12 digit mobile phone number, this fix add support for it.