### PR TITLE
Extended support for all Israel phone numbers

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -833,8 +833,8 @@ var iso3166_data = [
 		alpha3: "ISR",
 		country_code: "972",
 		country_name: "Israel",
-		mobile_begin_with: ["5"],
-		phone_number_lengths: [9]
+		mobile_begin_with: ["1", "2", "3", "4", "5", "7", "8", "9"],
+		phone_number_lengths: [8, 9, 11]
 	},
 	{
 		alpha2: "IT",


### PR DESCRIPTION
Will now support validating all Israel phone numbers and not just mobile phone numbers.