### PR TITLE
use strict typo corrected

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,4 @@
-'use stricts';
+'use strict';
 
 const iso3166_data = require('./iso3166_data');
 


### PR DESCRIPTION
The typo creates an error in IE 10