### PR TITLE
cn add phone begin with 19 and 16

### DIFF
--- a/lib/iso3166Data.js
+++ b/lib/iso3166Data.js
@@ -351,7 +351,7 @@ module.exports = [
 		alpha3: 'CHN',
 		country_code: '86',
 		country_name: 'China',
-		mobile_begin_with: ['13', '14', '15', '17', '18'],
+		mobile_begin_with: ['13', '14', '15', '17', '18', '19', '16'],
 		phone_number_lengths: [11]
 	},
 	{


### PR DESCRIPTION
I don't know if this two rules is included in iso3166, but tel companies in china have started allocating numbers start with 19 and 16 to customers. 