### PR TITLE
support south africa numbers begin with 1,2,3,4,5

### DIFF
--- a/lib/iso3166Data.js
+++ b/lib/iso3166Data.js
@@ -1854,7 +1854,7 @@ module.exports = [
 		alpha3: 'ZAF',
 		country_code: '27',
 		country_name: 'South Africa',
-		mobile_begin_with: ['6', '7', '8'],
+		mobile_begin_with: ['1', '2', '3', '4', '5', 6', '7', '8'],
 		phone_number_lengths: [9]
 	},
 	{

--- a/lib/iso3166Data.js
+++ b/lib/iso3166Data.js
@@ -1854,7 +1854,7 @@ module.exports = [
 		alpha3: 'ZAF',
 		country_code: '27',
 		country_name: 'South Africa',
-		mobile_begin_with: ['1', '2', '3', '4', '5', 6', '7', '8'],
+		mobile_begin_with: ['1', '2', '3', '4', '5', '6', '7', '8'],
 		phone_number_lengths: [9]
 	},
 	{


### PR DESCRIPTION
Add south africa numbers suppoort for numbers begin with `1`, `2`, `3`, `4`, `5`

see here: https://en.wikipedia.org/wiki/Telephone_numbers_in_South_Africa