### PR TITLE
Taiwan's mobile numbers are special

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -741,7 +741,7 @@ describe('Testing BRA Phone Quick Test', () => {
 	});
 });
 
-describe.only('Testing TW Phone Quick Test', () => {
+describe('Testing TW Phone Quick Test', () => {
 	describe('Test 1', () => {
 		const number = '+886-09-123-45678';
 		const country = 'TW';

--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -741,29 +741,29 @@ describe('Testing BRA Phone Quick Test', () => {
 	});
 });
 
-describe('Testing PRI Phone Quick Test', () => {
+describe.only('Testing TW Phone Quick Test', () => {
 	describe('Test 1', () => {
-		const number = '+1-787-672-9999';
-		const country = 'PRI';
-		const result = ['+17876729999', 'PRI'];
+		const number = '+886-09-123-45678';
+		const country = 'TW';
+		const result = ['+886912345678', 'TWN'];
 		test('returns ' + result, () => {
 			expect(phone(number, country)).toEqual(result);
 		});
 	});
 
 	describe('Test 2', () => {
-		const number = '17876729999';
-		const country = 'PRI';
-		const result = ['+17876729999', 'PRI'];
+		const number = '8860912345678';
+		const country = 'TW';
+		const result = ['+886912345678', 'TWN'];
 		test('returns ' + result, () => {
 			expect(phone(number, country)).toEqual(result);
 		});
 	});
 
 	describe('Test 3', () => {
-		const number = '7876729999';
-		const country = 'PRI';
-		const result = ['+17876729999', 'PRI'];
+		const number = '0912345678';
+		const country = 'TW';
+		const result = ['+886912345678', 'TWN'];
 		test('returns ' + result, () => {
 			expect(phone(number, country)).toEqual(result);
 		});
@@ -823,6 +823,35 @@ describe('Testing RUS Phone Quick Test', () => {
 			expect(phone(number, country)).toEqual(result);
 		});
 	});
+});
+
+describe('Testing PRI Phone Quick Test', () => {
+  describe('Test 1', () => {
+    const number = '+1-787-672-9999';
+    const country = 'PRI';
+    const result = ['+17876729999', 'PRI'];
+    test('returns ' + result, () => {
+      expect(phone(number, country)).toEqual(result);
+    });
+  });
+
+  describe('Test 2', () => {
+    const number = '17876729999';
+    const country = 'PRI';
+    const result = ['+17876729999', 'PRI'];
+    test('returns ' + result, () => {
+      expect(phone(number, country)).toEqual(result);
+    });
+  });
+
+  describe('Test 3', () => {
+    const number = '7876729999';
+    const country = 'PRI';
+    const result = ['+17876729999', 'PRI'];
+    test('returns ' + result, () => {
+      expect(phone(number, country)).toEqual(result);
+    });
+  });
 });
 
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -41,6 +41,18 @@ module.exports = function (phone, country) {
 			formatPhone = formatPhone.replace(/^0+/, '');
 		}
 
+		// Taiwan is special, see: https://en.wikipedia.org/wiki/Telephone_numbers_in_Taiwan
+		// Taiwan mobile phone numbers always begin with 09 followed by 8 digits (e.g. 0912-345678).
+		// The 0 is omitted when calling a Taiwan mobile phone number from outside Taiwan (e.g. +886 9XXXXXXXX)
+		// If the number starts with 09 (calling from inside), remove the zero.
+		if (iso3166.alpha3 === 'TWN') {
+			const countryCodeWithInsideMobile = new RegExp(`^${iso3166.country_code}09`);
+			const countryCodeWithOutsideMobile = `${iso3166.country_code}9`;
+			if (formatPhone.length === 13 && formatPhone.match(countryCodeWithInsideMobile) !== null) {
+        formatPhone = formatPhone.replace(countryCodeWithInsideMobile, countryCodeWithOutsideMobile);
+			}
+		}
+
 		// if input 89234567890, RUS, remove the 8
 		if (iso3166.alpha3 === 'RUS' && formatPhone.length === 11 && formatPhone.match(/^89/) !== null) {
 			formatPhone = formatPhone.replace(/^8+/, '');

--- a/lib/index.js
+++ b/lib/index.js
@@ -49,7 +49,7 @@ module.exports = function (phone, country) {
 			const countryCodeWithInsideMobile = new RegExp(`^${iso3166.country_code}09`);
 			const countryCodeWithOutsideMobile = `${iso3166.country_code}9`;
 			if (formatPhone.length === 13 && formatPhone.match(countryCodeWithInsideMobile) !== null) {
-        formatPhone = formatPhone.replace(countryCodeWithInsideMobile, countryCodeWithOutsideMobile);
+				formatPhone = formatPhone.replace(countryCodeWithInsideMobile, countryCodeWithOutsideMobile);
 			}
 		}
 


### PR DESCRIPTION
This is a wikipedia quote:

> Taiwan mobile phone numbers always begin with 09 followed by 8 digits (e.g. 0912-345678). The 0 is omitted when calling a Taiwan mobile phone number from outside Taiwan (e.g. +886 9XXXXXXXX). If calling a landline Taiwan phone number from a local Taiwan mobile phone, the 0 of area code prefix must be included (e.g. 0 + area code + 8 digit landline number).
> 
> Prefixes: (09)XXXX-XXXX

And since one of our project have to support both format as user input, I decided to implement it here also. 