### PR TITLE
Fix Greenland mobile prefix

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -975,7 +975,6 @@ describe('Testing MUS Phone Quick Test', () => {
 
 });
 
-
 describe('Testing CHN Phone Quick Test', () => {
 
     //Test for new pattern (199, 198, 166)
@@ -1003,6 +1002,28 @@ describe('Testing CHN Phone Quick Test', () => {
         });
     });
 
+});
 
-
+describe('Testing GRL numbers', () => {
+	describe('Test for numbers starting with 5', () => {
+		const number = '+299 555299';
+		const result = ['+299555299', 'GRL'];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
+	describe('Test for numbers starting with 2', () => {
+		const number = '+299 233299';
+		const result = ['+299233299', 'GRL'];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
+	describe('Test for landlines', () => {
+		const number = '+299 321000';
+		const result = [];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
 });

--- a/lib/iso3166Data.js
+++ b/lib/iso3166Data.js
@@ -706,7 +706,7 @@ module.exports = [
 		alpha3: 'GRL',
 		country_code: '299',
 		country_name: 'Greenland',
-		mobile_begin_with: ['4', '5'],
+		mobile_begin_with: ['2', '4', '5'],
 		phone_number_lengths: [6]
 	},
 	{


### PR DESCRIPTION
Greenland mobile phones can also start with a `2`
Source:
https://www.itu.int/oth/T0202000056/en