### PR TITLE
Argentina: fix length and prefix

### DIFF
--- a/__tests__/index.js
+++ b/__tests__/index.js
@@ -975,34 +975,56 @@ describe('Testing MUS Phone Quick Test', () => {
 
 });
 
-
 describe('Testing CHN Phone Quick Test', () => {
 
-    //Test for new pattern (199, 198, 166)
-    describe('Test for pattern 199', () => {
-        const number = '+86 199 51343779';
-        const result = ['+8619951343779', 'CHN'];
-        test('returns ' + result, () => {
-            expect(phone(number)).toEqual(result);
-        });
-    });
+	//Test for new pattern (199, 198, 166)
+	describe('Test for pattern 199', () => {
+		const number = '+86 199 51343779';
+		const result = ['+8619951343779', 'CHN'];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
 
-    describe('Test for pattern 198', () => {
-        const number = '+86 198 51343779';
-        const result = ['+8619851343779', 'CHN'];
-        test('returns ' + result, () => {
-            expect(phone(number)).toEqual(result);
-        });
-    });
+	describe('Test for pattern 198', () => {
+		const number = '+86 198 51343779';
+		const result = ['+8619851343779', 'CHN'];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
 
-    describe('Test for pattern 166', () => {
-        const number = '+86 166 51343779';
-        const result = ['+8616651343779', 'CHN'];
-        test('returns ' + result, () => {
-            expect(phone(number)).toEqual(result);
-        });
-    });
+	describe('Test for pattern 166', () => {
+		const number = '+86 166 51343779';
+		const result = ['+8616651343779', 'CHN'];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
+});
 
+describe('Testing ARG numbers', () => {
+	describe('Test for number without 9 prefix', () => {
+		const number = '+54 233 123 4567';
+		const result = ['+542331234567', 'ARG'];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
 
+	describe('Test for number with 9 prefix', () => {
+		const number = '+54 9 233 123 4567';
+		const result = [];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
 
+	describe('Test for number with 15 prefix', () => {
+		const number = '+54 15 233 123 4567';
+		const result = [];
+		test('returns ' + result, () => {
+			expect(phone(number)).toEqual(result);
+		});
+	});
 });

--- a/lib/iso3166Data.js
+++ b/lib/iso3166Data.js
@@ -101,8 +101,8 @@ module.exports = [
 		alpha3: 'ARG',
 		country_code: '54',
 		country_name: 'Argentina',
-		mobile_begin_with: [],
-		phone_number_lengths: [6, 7, 8, 9]
+		mobile_begin_with: ['1','2', '3'], // Same for mobile and landlines
+		phone_number_lengths: [10]
 	},
 	{
 		alpha2: 'AM',


### PR DESCRIPTION
Mobile phones in Argentina have the same length as land lines, and the same area codes. The total number length is 10, with the area code being between 2 digits and 4, and the actual number between 8 and 6.

Area codes all start with either 1,2, or 3.

When calling mobile phones locally, the `15` prefix is added after the area code.
When calling mobile phones internationally the `9` prefix is added before the area code.
When sending SMS - no prefix is added.

Source: 
https://faq.whatsapp.com/en/general/21016748
https://www.itu.int/oth/T0202000009/en
https://en.wikipedia.org/wiki/Telephone_numbers_in_Argentina
