### PR TITLE
Disabling temporarily source-map

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -5,7 +5,8 @@ const MinifyPlugin = require('babel-minify-webpack-plugin');
 const webpack = require('webpack');
 
 module.exports = {
-	devtool: 'source-map',
+	// devtool: 'source-map',
+	devtool: 'none',
 	entry: './lib/index.js',
 	output: {
 		path: path.resolve(__dirname, 'dist'),


### PR DESCRIPTION
Workaround to https://github.com/AfterShip/phone/issues/151

Due to https://github.com/webpack-contrib/babel-minify-webpack-plugin/issues/68