### PR TITLE
Add 9 to Italy's phone_number_lenghts

### DIFF
--- a/lib/iso3166Data.js
+++ b/lib/iso3166Data.js
@@ -846,7 +846,7 @@ module.exports = [
 		country_code: '39',
 		country_name: 'Italy',
 		mobile_begin_with: ['3'],
-		phone_number_lengths: [10]
+		phone_number_lengths: [9, 10]
 	},
 	{
 		alpha2: 'JM',


### PR DESCRIPTION
Hello.
I've added 9 to Italy's phone_number_lengths.
Proof:
"Mobile phone numbers start with the digit 3 and are generally 10 digits long. It is still possible, but rare, to find 9 digits long numbers: those were the first to be assigned"
from
https://ipfs.io/ipfs/QmXoypizjW3WknFiJnKLwHCnL72vedxjQkDDP1mXWo6uco/wiki/Telephone_numbers_in_Italy.html

You can also validate it here
(ex. +39 333 994 999)
https://numverify.com/

I've added it because of real-life scenario where user from Italy couldn't pass the validation because of his 9 digits long number.

Thank you!