### PR TITLE
Update MT mobile number prefix rule

### DIFF
--- a/lib/iso3166Data.js
+++ b/lib/iso3166Data.js
@@ -1118,7 +1118,7 @@ module.exports = [
 		alpha3: 'MLT',
 		country_code: '356',
 		country_name: 'Malta',
-		mobile_begin_with: ['79', '99'],
+		mobile_begin_with: ['7', '99'],
 		phone_number_lengths: [8]
 	},
 	{

--- a/lib/iso3166Data.js
+++ b/lib/iso3166Data.js
@@ -1118,7 +1118,7 @@ module.exports = [
 		alpha3: 'MLT',
 		country_code: '356',
 		country_name: 'Malta',
-		mobile_begin_with: ['7', '99'],
+		mobile_begin_with: ['7', '9'],
 		phone_number_lengths: [8]
 	},
 	{


### PR DESCRIPTION
Maltese mobile phone numbers can begin with `7<anything>`.