### PR TITLE
fix: extend the GB number length limits

### DIFF
--- a/lib/iso3166Data.js
+++ b/lib/iso3166Data.js
@@ -625,7 +625,7 @@ module.exports = [
 		country_code: '44',
 		country_name: 'United Kingdom',
 		mobile_begin_with: ['7'],
-		phone_number_lengths: [10]
+		phone_number_lengths: [7, 9, 10]
 	},
 	{
 		alpha2: 'GE',


### PR DESCRIPTION
https://github.com/AfterShip/phone/issues/167

GB number can be 7 or 9 digits long. Please refer to https://en.wikipedia.org/wiki/Telephone_numbers_in_the_United_Kingdom