### PR TITLE
fix Swiss (CHE) mobile_begin_with

### DIFF
--- a/lib/iso3166Data.js
+++ b/lib/iso3166Data.js
@@ -342,7 +342,7 @@ module.exports = [
 		alpha3: 'CHE',
 		country_code: '41',
 		country_name: 'Switzerland',
-		mobile_begin_with: ['7'],
+		mobile_begin_with: ['74', '75', '76', '77', '78', '79'],
 		phone_number_lengths: [9]
 	},
 	{


### PR DESCRIPTION
Corrected the prefix of mobile phone numbers in Switzerland according to 
https://en.wikipedia.org/wiki/Telephone_numbers_in_Switzerland

and my own experience having a landline number starting with 71 ;-)