### PR TITLE
Include CodeSandbox link in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,6 +29,9 @@ or
 yarn add phone
 ```
 
+## Demo
+
+[Try it on CodeSandbox](https://codesandbox.io/s/phone-browser-example-kcbdk?file=/src/index.js)
 
 ## Usage
 ```javascript


### PR DESCRIPTION
Hi big fan of this library!

I know you already have an example in the code, but I noticed I needed to clone, install, run... before I could try and see if I wanted to use the library.

I think it could help this library grow if there was an easy and quick way to demo and try the library out. 

I ported the example to a CodeSandbox link and added a `allowLandline` checkbox so users could immediately demo and test out the library. 

Let me know what you think. Happy to transfer ownership of the sandbox. 

https://codesandbox.io/s/phone-browser-example-kcbdk?file=/src/index.js
