### PR TITLE
Update CodeSandbox link to a working link

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ yarn add phone
 
 ## Demo
 
-[Try it on CodeSandbox](https://codesandbox.io/s/phone-browser-example-kcbdk?file=/src/index.js)
+[Try it on CodeSandbox](https://codesandbox.io/s/phone-browser-example-react-o5vt5?file=/src/App.js)
 
 ## Usage
 ```javascript


### PR DESCRIPTION
First of all, apologies. I was doing some more testing on my change and noticed a weird issue where the sandbox was not working with a new page reload. The sandbox currently says it has only been viewed 8 times, many probably from myself, so the impact should be quite low.

I believe the issue is from CodeSandbox's Vanilla JS mode, and I've alerted their team of the issue.

To solve this:
I created a new version in React of the sandbox and it is working well. 

https://codesandbox.io/s/phone-browser-example-react-o5vt5?file=/src/App.js

Thank you, and once again, sorry about the issue!