### PR TITLE
fix: MUS incorrect int type in mobile_begin_with

### DIFF
--- a/lib/iso3166Data.js
+++ b/lib/iso3166Data.js
@@ -1190,7 +1190,7 @@ module.exports = [
 		alpha3: 'MUS',
 		country_code: '230',
 		country_name: 'Mauritius',
-		mobile_begin_with: [5],
+		mobile_begin_with: ['5'],
 		phone_number_lengths: [8]
 	},
 	{


### PR DESCRIPTION
Fix the inconsistent `mobile_begin_with` for MUS.