### PR TITLE
feat(index): adjust the way of exporting method

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -16,7 +16,7 @@ import {
  * @param {Option} option
  * @returns {{phoneNumber: string|null, countryIso2: string|null, countryIso3: string|null}}
  */
-export default function (phoneNumber: string, {
+export default function phone(phoneNumber: string, {
 	country = '',
 	validateMobilePrefix = true,
 	strictDetection = false
@@ -125,5 +125,6 @@ export default function (phoneNumber: string, {
 };
 
 export {
+	phone,
 	countryPhoneData,
 };


### PR DESCRIPTION
support two way to using the `phone`:

Typescript
```typescript
import { phone } from 'phone';

import phone from 'phone';
```

JS
```javascript
const { phone } = require('phone');

const phone = require('phone').default;
```