### PR TITLE
Fix NZ mobile prefix

### DIFF
--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -1308,7 +1308,7 @@ export default [
 		alpha3: 'NZL',
 		country_code: '64',
 		country_name: 'New Zealand',
-		mobile_begin_with: ['2', '3', '6', '9'],
+		mobile_begin_with: ['2'],
 		phone_number_lengths: [8, 9, 10]
 	},
 	{


### PR DESCRIPTION
Currently it includes various regions prefixes, but it should only include '2' - https://en.wikipedia.org/wiki/Telephone_numbers_in_New_Zealand#Mobile_phones