### PR TITLE
Fix Peru

### DIFF
--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -1341,8 +1341,8 @@ export default [
 		alpha3: 'PER',
 		country_code: '51',
 		country_name: 'Peru',
-		mobile_begin_with: ['9', '6'],
-		phone_number_lengths: [9, 8]
+		mobile_begin_with: ['9'],
+		phone_number_lengths: [9]
 	},
 	{
 		alpha2: 'PH',


### PR DESCRIPTION
Based on this Wiki page mobile numbers in Peru start with 9 and continues with 8 digits afterwards: https://en.wikipedia.org/wiki/Telephone_numbers_in_Peru#Calling_a_mobile_number