### PR TITLE
Fix SJ numbers

### DIFF
--- a/__tests__/data.csv
+++ b/__tests__/data.csv
@@ -166,3 +166,5 @@ input_phone,input_country,not_validate_prefix,output_phone,output_country_alpha2
 +44 079111 23456,,,+447911123456,GB,GBR,+44,true,,Test strict detect switch,"returns +447911123456,GBR",
 +44 079111 23456,,,,,,,false,,,returns empty result for strict detect,true
 +44 079111 23456,,,+447911123456,GB,GBR,+44,true,,"returns +447911123456,GBR for explicitly false",false,
++4710000000,,,,,,,false,Testing NO / SJ numbers,Should not be valid NO or SJ,returns,
++4779000000,,,+4779000000,SJ,SJM,+47,true,,Should be SJ (Svalbard / Jan Mayen),"returns +4779000000,SJM",

--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -1509,7 +1509,7 @@ export default [
 		alpha3: 'SJM',
 		country_code: '47',
 		country_name: 'Svalbard And Jan Mayen',
-		mobile_begin_with: [],
+		mobile_begin_with: [79],
 		phone_number_lengths: [8]
 	},
 	{


### PR DESCRIPTION
Hi! First time contributor here, so apologies if there's anything I've missed. 

I was having an issue where invalid Norwegian mobile phone numbers like `+47 1xxx xxxx` was incorrectly labeled as valid mobile phone numbers in Svalbard / Jan Mayen (SJ/SJM). 

This was caused by SJ/SJM was missing a `mobile_begin_with` value, which should be 79 (see Svalbard and Jan Mayen in https://en.wikipedia.org/wiki/List_of_mobile_telephone_prefixes_by_country)


This PR makes sure that 

1. Only `+47 4xxx xxxx` and `+47 9xxx xxxx` are valid Norwegain mobile phone numbers <!--['4', '9'],-->
2. Only `+47 79xx xxxx` are valid Svalbard / Jan Mayen mobile phone numbers