### PR TITLE
Extend Bolivia to accept mobile phones beginning with 6

### DIFF
--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -257,7 +257,7 @@ export default [
 		alpha3: 'BOL',
 		country_code: '591',
 		country_name: 'Bolivia',
-		mobile_begin_with: ['7'],
+		mobile_begin_with: ['6', '7'],
 		phone_number_lengths: [8]
 	},
 	{


### PR DESCRIPTION
According to [Wikipedia](https://en.wikipedia.org/wiki/Telephone_numbers_in_Bolivia), Bolivia has started to accept mobile phones that start with `6`, in addition to `7` (See cellphones at the bottom)

![image](https://user-images.githubusercontent.com/352474/137569802-ab8601d0-606c-47c6-b9c2-22844cb229b4.png)


The Spanish version has a bit more info, stating that it is a recent change. See [here](https://es.wikipedia.org/wiki/Anexo:Prefijos_telef%C3%B3nicos_de_Bolivia)

I failed to find an official regulation, but several pages, [such as this one](https://www.sprint.com/en/support/solutions/international/international-mobile-dial-codes.html) also include 6 as a valid prefix