### PR TITLE
Enhance type definitions

### DIFF
--- a/__tests__/index.spec.ts
+++ b/__tests__/index.spec.ts
@@ -39,7 +39,7 @@ describe('Parameter types', () => {
 
 	test('country is not a string', () => {
 		const result = phone('+18175698900', {
-			country: 123 as unknown as string
+			country: 123 as any,
 		});
 
 		expect(result).toEqual({

--- a/__tests__/test_match.ts
+++ b/__tests__/test_match.ts
@@ -35,7 +35,7 @@ for (const testCase of testCases) {
 		}
 
 		const result = phone(phoneNumber, {
-			country,
+			country: country as "USA",
 			validateMobilePrefix,
 			strictDetection
 		});

--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -1884,4 +1884,4 @@ export default [
 		mobile_begin_with: ['71', '73', '77'],
 		phone_number_lengths: [9]
 	}
-];
+] as const;

--- a/src/index.ts
+++ b/src/index.ts
@@ -3,8 +3,11 @@ import {
 	findCountryPhoneDataByCountry,
 	findCountryPhoneDataByPhoneNumber,
 	validatePhoneISO3166,
-	CountryPhoneDataItem,
 	includes,
+	TSupportedCountryIso2,
+	TSupportedCountryIso3,
+	TSupportedCountryCountryCode,
+	TSupportedCountryIso,
 } from './lib/utility';
 
 export interface PhoneInvalidResult {
@@ -14,13 +17,13 @@ export interface PhoneInvalidResult {
 	countryIso3: null;
 	countryCode: null;
 }
-  
+
 export interface PhoneValidResult {
 	isValid: true;
 	phoneNumber: `+${string}`;
-	countryIso2: CountryPhoneDataItem["alpha2"];
-	countryIso3: CountryPhoneDataItem["alpha3"];
-	countryCode: `+${CountryPhoneDataItem["country_code"]}`;
+	countryIso2: TSupportedCountryIso2;
+	countryIso3: TSupportedCountryIso3;
+	countryCode: `+${TSupportedCountryCountryCode}`;
 }
   
 export type PhoneResult = PhoneInvalidResult | PhoneValidResult; 
@@ -40,7 +43,7 @@ export default function phone(phoneNumber: string, {
 	validateMobilePrefix = true,
 	strictDetection = false
 }: {
-	country?: CountryPhoneDataItem["alpha2"] | CountryPhoneDataItem["alpha3"] | '';
+	country?: TSupportedCountryIso | '';
 	validateMobilePrefix?: boolean;
 	strictDetection?: boolean;
 } = {}): PhoneResult {
@@ -53,7 +56,7 @@ export default function phone(phoneNumber: string, {
 	};
 
 	let processedPhoneNumber = (typeof phoneNumber !== 'string') ? '' : phoneNumber.trim();
-	const processedCountry = ((typeof country !== 'string') ? '' : country.trim()) as CountryPhoneDataItem["alpha2"] | CountryPhoneDataItem["alpha3"];
+	const processedCountry = ((typeof country !== 'string') ? '' : country.trim()) as TSupportedCountryIso;
 	const hasPlusSign = Boolean(processedPhoneNumber.match(/^\+/));
 
 	// remove any non-digit character, included the +

--- a/src/lib/utility.ts
+++ b/src/lib/utility.ts
@@ -7,7 +7,7 @@ export type CountryPhoneDataItem = GetArrayElementType<typeof countryPhoneData>;
  * @param {string=} country - country code alpha 2 or 3
  * @returns {{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with, phone_number_lengths: [number]}|{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with: [string, string, string, string], phone_number_lengths: [number]}|{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with: [string], phone_number_lengths: [number]}|{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with: [string], phone_number_lengths: [number]}|{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with: [string, string], phone_number_lengths: [number]}|null}
  */
-export function findCountryPhoneDataByCountry(country: string) {
+export function findCountryPhoneDataByCountry(country: CountryPhoneDataItem["alpha2"] | CountryPhoneDataItem["alpha3"]): CountryPhoneDataItem| null{
 	// if no country provided, assume it's USA
 	if (!country) {
 		return countryPhoneData.find(countryPhoneDatum => countryPhoneDatum.alpha3 === 'USA') || null;
@@ -24,7 +24,7 @@ export function findCountryPhoneDataByCountry(country: string) {
 	return countryPhoneData.find(countryPhoneDatum => country.toUpperCase() === countryPhoneDatum.country_name.toUpperCase()) || null;
 }
 
-export function findExactCountryPhoneData(phoneNumber: string, validateMobilePrefix: boolean, countryPhoneDatum: CountryPhoneDataItem) {
+export function findExactCountryPhoneData(phoneNumber: string, validateMobilePrefix: boolean, countryPhoneDatum: CountryPhoneDataItem): null | CountryPhoneDataItem {
 	// check if the phone number length match any one of the length config
 	const phoneNumberLengthMatched = countryPhoneDatum.phone_number_lengths.some(length => {
 		// as the phone number must include the country code,
@@ -53,7 +53,7 @@ export function findExactCountryPhoneData(phoneNumber: string, validateMobilePre
 	return null;
 }
 
-export function findPossibleCountryPhoneData(phoneNumber: string, validateMobilePrefix: boolean, countryPhoneDatum: CountryPhoneDataItem) {
+export function findPossibleCountryPhoneData(phoneNumber: string, validateMobilePrefix: boolean, countryPhoneDatum: CountryPhoneDataItem): null | CountryPhoneDataItem {
 	// check if the phone number length match any one of the length config
 	const phoneNumberLengthMatched = countryPhoneDatum.phone_number_lengths.some(length => {
 		// the phone number must include the country code
@@ -79,6 +79,7 @@ export function findPossibleCountryPhoneData(phoneNumber: string, validateMobile
 	})) {
 		return countryPhoneDatum;
 	}
+	return null;
 }
 
 /**
@@ -88,9 +89,9 @@ export function findPossibleCountryPhoneData(phoneNumber: string, validateMobile
  * @param validateMobilePrefix
  * @returns {{exactCountryPhoneData: (*), possibleCountryPhoneData: (*)}}
  */
-export function findCountryPhoneDataByPhoneNumber(phoneNumber: string, validateMobilePrefix: boolean) {
-	let exactCountryPhoneData;
-	let possibleCountryPhoneData;
+export function findCountryPhoneDataByPhoneNumber(phoneNumber: string, validateMobilePrefix: boolean): { exactCountryPhoneData: CountryPhoneDataItem | null, possibleCountryPhoneData: CountryPhoneDataItem | null } {
+	let exactCountryPhoneData: CountryPhoneDataItem | null = null;
+	let possibleCountryPhoneData: CountryPhoneDataItem | null = null;
 
 	for (const countryPhoneDatum of countryPhoneData) {
 		// if the country code is wrong, skip directly
@@ -126,7 +127,7 @@ export function findCountryPhoneDataByPhoneNumber(phoneNumber: string, validateM
  * @param {boolean} plusSign - true if the input contains a plus sign
  * @returns {*|boolean}
  */
-export function validatePhoneISO3166(phone: string, countryPhoneDatum: CountryPhoneDataItem, validateMobilePrefix: boolean, plusSign: boolean) {
+export function validatePhoneISO3166(phone: string, countryPhoneDatum: CountryPhoneDataItem, validateMobilePrefix: boolean, plusSign: boolean): boolean {
 	if (!countryPhoneDatum.phone_number_lengths) {
 		return false;
 	}
@@ -151,4 +152,9 @@ export function validatePhoneISO3166(phone: string, countryPhoneDatum: CountryPh
 		true;
 
 	return isLengthValid && (!validateMobilePrefix || isBeginWithValid);
+}
+
+// to allow use .includes on narrow types (as const) – better to use a separate method with better type definitions.
+export function includes<T extends U, U>(coll: ReadonlyArray<T>, el: U): el is T {
+	return coll.includes(el as T);
 }

--- a/src/lib/utility.ts
+++ b/src/lib/utility.ts
@@ -1,13 +1,16 @@
 import countryPhoneData from '../data/country_phone_data';
 
-type GetArrayElementType<T extends readonly any[]> = T extends readonly (infer U)[] ? U : never;
-export type CountryPhoneDataItem = GetArrayElementType<typeof countryPhoneData>;
+export type CountryPhoneDataItem = typeof countryPhoneData[number];
+export type TSupportedCountryIso2 = CountryPhoneDataItem['alpha2'];
+export type TSupportedCountryIso3 = CountryPhoneDataItem['alpha3'];
+export type TSupportedCountryCountryCode = CountryPhoneDataItem['country_code'];
+export type TSupportedCountryIso = TSupportedCountryIso2 | TSupportedCountryIso3;
 
 /**
  * @param {string=} country - country code alpha 2 or 3
  * @returns {{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with, phone_number_lengths: [number]}|{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with: [string, string, string, string], phone_number_lengths: [number]}|{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with: [string], phone_number_lengths: [number]}|{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with: [string], phone_number_lengths: [number]}|{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with: [string, string], phone_number_lengths: [number]}|null}
  */
-export function findCountryPhoneDataByCountry(country: CountryPhoneDataItem["alpha2"] | CountryPhoneDataItem["alpha3"]): CountryPhoneDataItem| null{
+export function findCountryPhoneDataByCountry(country: TSupportedCountryIso): CountryPhoneDataItem| null{
 	// if no country provided, assume it's USA
 	if (!country) {
 		return countryPhoneData.find(countryPhoneDatum => countryPhoneDatum.alpha3 === 'USA') || null;


### PR DESCRIPTION
Enhance lib type definitions, make them more stricter.

Make them depend on initial data to exclude parsing numbers of not included countries and avoid mistakes on client when setting/checking input/output country.