### PR TITLE
update mobile prefixes for Fiji

### DIFF
--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -572,7 +572,7 @@ export default [
 		alpha3: 'FJI',
 		country_code: '679',
 		country_name: 'Fiji',
-		mobile_begin_with: ['7', '9', '8', '2'],
+		mobile_begin_with: ['2', '7', '8', '9'],
 		phone_number_lengths: [7]
 	},
 	{

--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -572,7 +572,7 @@ export default [
 		alpha3: 'FJI',
 		country_code: '679',
 		country_name: 'Fiji',
-		mobile_begin_with: ['7', '9'],
+		mobile_begin_with: ['7', '9', '8', '2'],
 		phone_number_lengths: [7]
 	},
 	{


### PR DESCRIPTION
https://en.wikipedia.org/wiki/Telephone_numbers_in_Fiji
"Mobile telephones are also seven digits long and begin with a 7,9,8 or 2."