### PR TITLE
Add number 2 in the beginning numbers of guatemala

### DIFF
--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -731,7 +731,7 @@ export default [
 		alpha3: 'GTM',
 		country_code: '502',
 		country_name: 'Guatemala',
-		mobile_begin_with: ['3', '4', '5'],
+		mobile_begin_with: ['2', '3', '4', '5'],
 		phone_number_lengths: [8]
 	},
 	{


### PR DESCRIPTION
The number 2 is added between the numbers with which the numbers of Guatemala begin.

For example:

- This is the website of the [government of Guatemala](https://sit.gob.gt/), its number is +502-2321-1000.
- You can also compare from the list of restaurants in Guatemala in gmaps.