### PR TITLE
Added missing numbers for Guatemala and Costa Rica

### DIFF
--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -731,7 +731,7 @@ export default [
 		alpha3: 'GTM',
 		country_code: '502',
 		country_name: 'Guatemala',
-		mobile_begin_with: ['3', '4', '5'],
+		mobile_begin_with: ['2', '3', '4', '5'],
 		phone_number_lengths: [8]
 	},
 	{

--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -440,7 +440,7 @@ export default [
 		alpha3: 'CRI',
 		country_code: '506',
 		country_name: 'Costa Rica',
-		mobile_begin_with: ['5', '6', '7', '8'],
+		mobile_begin_with: ['2', '5', '6', '7', '8'],
 		phone_number_lengths: [8]
 	},
 	{


### PR DESCRIPTION
The number 2 is added between the numbers with which the numbers of Guatemala begin.

Resources:
- This is the website of the [government of Guatemala](https://sit.gob.gt/), its number is +502-2321-1000.
- You can also compare from the list of restaurants in Guatemala in gmaps. :)

---------------------------------------------------------------------------------------------------------------------------------

The number 2 is added between the numbers with which the numbers of Costa Rica begin.

Resources:
- You can compare from the [list of restaurants](https://www.google.com/search?tbs=lf:1,lf_ui:9&tbm=lcl&q=costa+rica+restaurants&rflfq=1&num=10&rldimm=1547382729196880844&ved=2ahUKEwj0kaO0oo7-AhU3rpUCHbBNC_EQu9QIegQIGRAL#rlfi=hd:;si:;mv:[[9.968178710777423,-84.02974020997125],[9.901727449795779,-84.13561236420709]]) in Costa Rica in gmaps. :)