### PR TITLE
Allow users to substitute phone number (country data) array rules

### DIFF
--- a/README.md
+++ b/README.md
@@ -196,12 +196,13 @@ phone(phoneNumber: string, { country, validateMobilePrefix, strictDetection }?: 
 
 #### Input
 
-Parameter | Type | Required | Default | Description
---- | --- | --- | --- | ---
-phoneNumber | String | Yes | - | The phone number text you want to process
-country | String | No | null | Provided country code in iso-3166 alpha 2 or 3 format
-validateMobilePrefix | Boolean | No | true | Set to false if you want to skip phone number initial digit checking
-strictDetection | Boolean | No | false | Set to true if you want to disable trunk code detection logic. 
+Parameter | Type | Required | Default   | Description
+--- | --- | --- |-----------| ---
+phoneNumber | String | Yes | -         | The phone number text you want to process
+country | String | No | null      | Provided country code in iso-3166 alpha 2 or 3 format
+validateMobilePrefix | Boolean | No | true      | Set to false if you want to skip phone number initial digit checking
+strictDetection | Boolean | No | false     | Set to true if you want to disable trunk code detection logic. 
+customCountryPhoneData | CountryPhoneDataItem[] | No | undefined | Allow define your custom rules for specific country. 
 
 #### Returns
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -37,11 +37,13 @@ export type PhoneResult = PhoneInvalidResult | PhoneValidResult;
 export default function phone(phoneNumber: string, {
 	country = '',
 	validateMobilePrefix = true,
-	strictDetection = false
+	strictDetection = false,
+	customCountryPhoneData = undefined,
 }: {
 	country?: string;
 	validateMobilePrefix?: boolean;
 	strictDetection?: boolean;
+	customCountryPhoneData?: CountryPhoneDataItem[];
 } = {}): PhoneResult {
 	const invalidResult = {
 		isValid: false as const,
@@ -58,7 +60,7 @@ export default function phone(phoneNumber: string, {
 	// remove any non-digit character, included the +
 	processedPhoneNumber = processedPhoneNumber.replace(/\D/g, '');
 
-	let foundCountryPhoneData = findCountryPhoneDataByCountry(processedCountry);
+	let foundCountryPhoneData = findCountryPhoneDataByCountry(processedCountry, customCountryPhoneData);
 
 	if (!foundCountryPhoneData) {
 		return invalidResult;
@@ -86,7 +88,7 @@ export default function phone(phoneNumber: string, {
 	} else if (hasPlusSign) {
 		// if there is a plus sign but no country provided
 		// try to find the country phone data by the phone number
-		const { exactCountryPhoneData, possibleCountryPhoneData } = findCountryPhoneDataByPhoneNumber(processedPhoneNumber, validateMobilePrefix);
+		const { exactCountryPhoneData, possibleCountryPhoneData } = findCountryPhoneDataByPhoneNumber(processedPhoneNumber, validateMobilePrefix, customCountryPhoneData);
 
 		if (exactCountryPhoneData) {
 			foundCountryPhoneData = exactCountryPhoneData;
@@ -128,7 +130,7 @@ export default function phone(phoneNumber: string, {
 
 	if (defaultCountry) {
 		// also try to validate against CAN for default country, as CAN is also start with +1
-		foundCountryPhoneData = findCountryPhoneDataByCountry('CAN') as CountryPhoneDataItem;
+		foundCountryPhoneData = findCountryPhoneDataByCountry('CAN', customCountryPhoneData) as CountryPhoneDataItem;
 		validateResult = validatePhoneISO3166(processedPhoneNumber, foundCountryPhoneData, validateMobilePrefix, hasPlusSign);
 		if (validateResult) {
 			return {

--- a/src/lib/utility.ts
+++ b/src/lib/utility.ts
@@ -7,21 +7,21 @@ export type CountryPhoneDataItem = GetArrayElementType<typeof countryPhoneData>;
  * @param {string=} country - country code alpha 2 or 3
  * @returns {{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with, phone_number_lengths: [number]}|{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with: [string, string, string, string], phone_number_lengths: [number]}|{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with: [string], phone_number_lengths: [number]}|{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with: [string], phone_number_lengths: [number]}|{country_code: string, alpha2: string, country_name: string, alpha3: string, mobile_begin_with: [string, string], phone_number_lengths: [number]}|null}
  */
-export function findCountryPhoneDataByCountry(country: string) {
+export function findCountryPhoneDataByCountry(country: string, customCountryPhoneData?: CountryPhoneDataItem[]) {
 	// if no country provided, assume it's USA
 	if (!country) {
-		return countryPhoneData.find(countryPhoneDatum => countryPhoneDatum.alpha3 === 'USA') || null;
+		return (customCountryPhoneData ?? countryPhoneData).find(countryPhoneDatum => countryPhoneDatum.alpha3 === 'USA') || null;
 	}
 
 	if (country.length === 2) {
-		return countryPhoneData.find(countryPhoneDatum => country.toUpperCase() === countryPhoneDatum.alpha2) || null;
+		return (customCountryPhoneData ?? countryPhoneData).find(countryPhoneDatum => country.toUpperCase() === countryPhoneDatum.alpha2) || null;
 	}
 
 	if (country.length === 3) {
-		return countryPhoneData.find(countryPhoneDatum => country.toUpperCase() === countryPhoneDatum.alpha3) || null;
+		return (customCountryPhoneData ?? countryPhoneData).find(countryPhoneDatum => country.toUpperCase() === countryPhoneDatum.alpha3) || null;
 	}
 
-	return countryPhoneData.find(countryPhoneDatum => country.toUpperCase() === countryPhoneDatum.country_name.toUpperCase()) || null;
+	return (customCountryPhoneData ?? countryPhoneData).find(countryPhoneDatum => country.toUpperCase() === countryPhoneDatum.country_name.toUpperCase()) || null;
 }
 
 export function findExactCountryPhoneData(phoneNumber: string, validateMobilePrefix: boolean, countryPhoneDatum: CountryPhoneDataItem) {
@@ -88,11 +88,11 @@ export function findPossibleCountryPhoneData(phoneNumber: string, validateMobile
  * @param validateMobilePrefix
  * @returns {{exactCountryPhoneData: (*), possibleCountryPhoneData: (*)}}
  */
-export function findCountryPhoneDataByPhoneNumber(phoneNumber: string, validateMobilePrefix: boolean) {
+export function findCountryPhoneDataByPhoneNumber(phoneNumber: string, validateMobilePrefix: boolean, customCountryPhoneData?: CountryPhoneDataItem[]) {
 	let exactCountryPhoneData;
 	let possibleCountryPhoneData;
 
-	for (const countryPhoneDatum of countryPhoneData) {
+	for (const countryPhoneDatum of (customCountryPhoneData ?? countryPhoneData)) {
 		// if the country code is wrong, skip directly
 		if (!phoneNumber.match(new RegExp('^' + countryPhoneDatum.country_code))) {
 			continue;


### PR DESCRIPTION
Due to this lib is not always up to date, user might need to substitute country data rule for specific geo or in general.