### PR TITLE
Handle case of landline phone in Thailand which has only 8 digits

### DIFF
--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -1694,7 +1694,7 @@ export default [
 		country_code: '66',
 		country_name: 'Thailand',
 		mobile_begin_with: ['6', '8', '9'],
-		phone_number_lengths: [9]
+		phone_number_lengths: [8, 9]
 	},
 	{
 		alpha2: 'TJ',


### PR DESCRIPTION
In Thailand, landline phone number has only 8 digits such as 2xxx0070.

To correct above fact, I add the case that make this lib support 8 digits phone number for Thailand.