### PR TITLE
Add new operator code for Ethiopia (Safaricom +2517 or 07) 

### DIFF
--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -588,7 +588,7 @@ export default [
 		alpha3: 'ETH',
 		country_code: '251',
 		country_name: 'Ethiopia',
-		mobile_begin_with: ['9'],
+		mobile_begin_with: ['7','9'],
 		phone_number_lengths: [9]
 	},
 	{


### PR DESCRIPTION
https://safaricom.et/index.php/news-insights/82-safaricom-ethiopia-progresses-its-national-network-expansion-by-switching-on-the-network-in-five-more-cities

To join the “07” network, customers will purchase a SIM Card for 30 Birr at any Safaricom Ethiopia branded shops and souks. Customers can also access these self-service options on the network:
