### PR TITLE
Add new operator for Netherlands

### DIFF
--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -1316,8 +1316,8 @@ export default [
 		alpha3: 'NLD',
 		country_code: '31',
 		country_name: 'Netherlands',
-		mobile_begin_with: ['6'],
-		phone_number_lengths: [9]
+		mobile_begin_with: ['6', '97'],
+		phone_number_lengths: [9, 11]
 	},
 	{
 		alpha2: 'NO',


### PR DESCRIPTION
https://issuetracker.google.com/issues/140508060?pli=1
https://en.wikipedia.org/wiki/Telephone_numbers_in_the_Netherlands

Added Netherlands M2M case code 97 (+3197xxxxxxxx)
- Added support for Netherlands M2M number format
- Example number format: +3197010586427