### PR TITLE
Allow 9 digit numbers from Bosnia and Herzegovina

### DIFF
--- a/__tests__/data.csv
+++ b/__tests__/data.csv
@@ -185,3 +185,5 @@ input_phone,input_country,not_validate_prefix,output_phone,output_country_alpha2
 +599 9683 1517,,,+59996831517,CW,CUW,+599,true,,,"returns ANT 2",
 +1 (353) 555-8900,,,+13535558900,US,USA,+1,true,,353 area code,"returns +13535558900,USA",
 +1 (645) 555-1234,,,+16455551234,US,USA,+1,true,,645 area code,"returns +16455551234,USA",
++387 620 12345,,,+38762012345,BA,BIH,+387,true,,Bosnia and Herzegovina 8 digit number,"returns +38762012345,BIH",
++387 6031 12345,,,+387603112345,BA,BIH,+387,true,,Bosnia and Herzegovina 9 digit number,"returns +387603112345,BIH",

--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -235,7 +235,7 @@ export default [
 		country_code: '387',
 		country_name: 'Bosnia and Herzegovina',
 		mobile_begin_with: ['6'],
-		phone_number_lengths: [8]
+		phone_number_lengths: [8, 9]
 	},
 	// {alpha2: "BL", alpha3: "BLM", country_code: "590", country_name: "Saint Barthélemy", mobile_begin_with: [], phone_number_lengths: []},
 	{


### PR DESCRIPTION
Added support for 9 digit phone numbers from Bosnia and Herzegovina. 

Based on information from information from Wikipedia, both 8 and 9 digit numbers are used by some providers: https://en.wikipedia.org/wiki/Telephone_numbers_in_Bosnia_and_Herzegovina#Mobile_phone_codes