### PR TITLE
add format numbers for guadeloupe & martinique

### DIFF
--- a/src/data/country_phone_data.ts
+++ b/src/data/country_phone_data.ts
@@ -693,7 +693,7 @@ export default [
 		alpha3: 'GLP',
 		country_code: '590',
 		country_name: 'Guadeloupe',
-		mobile_begin_with: ['690'],
+		mobile_begin_with: ['690', '691'],
 		phone_number_lengths: [9]
 	},
 	{
@@ -1220,7 +1220,7 @@ export default [
 		alpha3: 'MTQ',
 		country_code: '596',
 		country_name: 'Martinique',
-		mobile_begin_with: ['696'],
+		mobile_begin_with: ['696', '697'],
 		phone_number_lengths: [9]
 	},
 	{


### PR DESCRIPTION
Hi, 

There is new format for numbers from martinique and guadeloupe. You can see a reference to it : 
[prixtel](https://www.prixtel.com/decouvrir-prixtel/actualite/news/comment-reconnaitre-un-numero-de-telephone-portable-des-dom-tom/?srsltid=AfmBOoplh_TENS2NHmx0LNdrhBhMPVGiw4xD-xz61XEooCSjlZfeKE3_) 
[legifrance](https://www.legifrance.gouv.fr/jorf/article_jo/JORFARTI000043910251) (screenshot below for this one)
<img width="1117" height="529" alt="SCR-20250813-ff9" src="https://github.com/user-attachments/assets/e12e929a-c23e-4235-9886-64dda15293b7" />
